### PR TITLE
feat: add v2 status helper with unified kind formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ app.get('/error', (_, reply) => reply.error(500, { message: 'something went wron
 - `{ kind: 'error', status, error }`
 - `{ kind: 'status', status, payload }`
 
+Default behavior when `format` is not provided:
+
+- `reply.error(status, { message })` → `{ error: { message } }`
+- `reply.status(status, payload)` → returns `payload` as-is
+- `reply.status(204, payload)` → sends no body (`204 No Content`)
+
 Use `format(input)` for all custom response formatting.
 
 ### License

--- a/README.md
+++ b/README.md
@@ -1,73 +1,62 @@
-# feh [![feh npm version](https://img.shields.io/npm/v/%40zhaoworks%2Ffeh)](https://www.npmjs.com/package/@zhaoworks/feh) [![last commit](https://img.shields.io/github/last-commit/zhaoworks/feh)](https://github.com/zhaoworks/feh/commits/main/)
+###### — @zhaoworks/feh
 
-> *feh* is a Fastify Error Responder, it's a plugin to facilitate and standardize error management in your Fastify application.
+Fastify reply helper for standardized status and error responses.
 
-## Usage
+#### Features
 
-### Installation
+- ✅ `reply.error(status, { message })`
+- ✅ `reply.status(status, payload)` for string or JSON payloads
+- ✅ Unified formatter with `kind` context (`error` or `status`)
 
-```sh
-bun add @zhaoworks/feh
+#### Installation
+
+```apache
+λ bun add @zhaoworks/feh
 ```
 
-<details>
-<summary>npm</summary>
-
-> ```sh
-> npm install @zhaoworks/feh
-> ```
-
-</details>
-
-<details>
-<summary>yarn</summary>
-
-> ```sh
-> yarn add @zhaoworks/feh
-> ```
-
-</details>
-
-<details>
-<summary>pnpm</summary>
-
-> ```sh
-> pnpm add @zhaoworks/feh
-> ```
-
-</details>
-
-### Example
-
-After adding [Fastify](https://fastify.dev/) and **feh** in your project, try this
+#### Usage
 
 ```ts
 import fastify from 'fastify';
 import feh from '@zhaoworks/feh';
 
-const server = fastify();
+const app = fastify();
 
-server.register(feh);
+app.register(feh, {
+  format: (input) => {
+    if (input.kind === 'error') {
+      return {
+        ok: false,
+        status: input.status,
+        message: input.error.message,
+      };
+    }
 
-server.get('/', (_, reply) => {
-  return reply.error(500, {
-    message: 'something went completely wrong >:(',
-  });
+    return {
+      ok: true,
+      status: input.status,
+      data: input.payload,
+    };
+  },
 });
 
-server
-  .listen({ port: 4000 })
-  .then(() => console.log('Listening on http://localhost:4000/'));
+app.get('/ok', (_, reply) => reply.status(200, { message: 'success' }));
+app.get('/accepted', (_, reply) => reply.status(202, 'accepted'));
+app.get('/error', (_, reply) => reply.error(500, { message: 'something went wrong' }));
 ```
 
-You can also add a custom format to your errors by registering a new error formatter.
+#### API
 
-```ts
-server.register(feh, {
-  format: (status, error) => ({ error: error.message, our_fault: status === 500 })
-});
+- `reply.error(status, { message })`
+- `reply.status(status, payload)`
 
-server.get('/', (_, reply) => {
-  return reply.error(500, { message: 'a cat must have bitten the wires' }); // -> { error: 'a cat must have bitten the wires', our_fault: true }
-});
-```
+`format(input)` receives:
+
+- `{ kind: 'error', status, error }`
+- `{ kind: 'status', status, payload }`
+
+Use `format(input)` for all custom response formatting.
+
+### License
+
+[MIT](/LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zhaoworks/feh",
-  "description": "fastify response errors.",
-  "version": "1.0.4",
+  "description": "Fastify response helper for status and error replies.",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Kauê Fraga Rodrigues <rkauefraga@gmail.com>",
   "repository": "https://github.com/zhaoworks/feh",

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,39 +33,43 @@ declare module 'fastify' {
 const DEFAULT_ERROR_FORMATTER = (_: number, error: ErrorOptions) => ({ error });
 const DEFAULT_STATUS_FORMATTER = (_: number, payload: unknown) => payload;
 
-function formatErrorPayload(status: number, error: ErrorOptions, plugin: PluginOptions) {
-  if (typeof plugin.format !== 'undefined') {
-    return plugin.format({ kind: 'error', status, error });
+function formatErrorPayload(status: number, error: ErrorOptions, options: PluginOptions) {
+  if (typeof options.format !== 'undefined') {
+    return options.format({ kind: 'error', status, error });
   }
 
   return DEFAULT_ERROR_FORMATTER(status, error);
 }
 
-function formatStatusPayload(status: number, payload: unknown, plugin: PluginOptions) {
-  if (typeof plugin.format !== 'undefined') {
-    return plugin.format({ kind: 'status', status, payload });
+function formatStatusPayload(status: number, payload: unknown, options: PluginOptions) {
+  if (typeof options.format !== 'undefined') {
+    return options.format({ kind: 'status', status, payload });
   }
 
   return DEFAULT_STATUS_FORMATTER(status, payload);
 }
 
-function patchStatusReplyMethod(reply: FastifyReply, plugin: PluginOptions) {
+function patchStatusReplyMethod(reply: FastifyReply, options: PluginOptions) {
   const originalStatus = reply.status.bind(reply) as StatusReplyMethod;
 
   reply.status = function patchedStatus(code: number, payload?: unknown) {
     const response = originalStatus(code);
 
     if (arguments.length >= 2) {
-      return response.send(formatStatusPayload(code, payload, plugin));
+      if (code === 204) {
+        return response.send();
+      }
+
+      return response.send(formatStatusPayload(code, payload, options));
     }
 
     return response;
   } as StatusReplyMethod;
 }
 
-async function plugin(fastify: FastifyInstance, plugin: PluginOptions) {
+async function plugin(fastify: FastifyInstance, options: PluginOptions) {
   fastify.addHook('onRequest', (_, reply, done) => {
-    patchStatusReplyMethod(reply, plugin);
+    patchStatusReplyMethod(reply, options);
     done();
   });
 
@@ -73,8 +77,8 @@ async function plugin(fastify: FastifyInstance, plugin: PluginOptions) {
    * Obs.: the anonymous function must not be an arrow function,
    * probably because of the way the Fastify uses `this` context.
    */
-  fastify.decorateReply('error', function (this, status, options) {
-    return this.status(status).send(formatErrorPayload(status, options, plugin));
+  fastify.decorateReply('error', function (this: FastifyReply, status: number, error: ErrorOptions) {
+    return this.status(status).send(formatErrorPayload(status, error, options));
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,80 @@
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 import fp from 'fastify-plugin';
 
 interface ErrorOptions {
   message: string;
 }
 
+type FormatInput =
+  | { kind: 'error'; status: number; error: ErrorOptions }
+  | { kind: 'status'; status: number; payload: unknown };
+
 interface PluginOptions {
-  format?: (status: number, error: ErrorOptions) => unknown;
+  /**
+   * Unified formatter for both `reply.error(...)` and `reply.status(code, payload)`.
+   */
+  format?: (input: FormatInput) => unknown;
 }
 
+type StatusReplyMethod = FastifyReply['status'];
+
 /*
- * Obs.: this declaration is necessary for including the method `error`
- * as a valid method of FastifyReply.
+ * Obs.: this declaration is necessary for including the methods
+ * as valid methods of FastifyReply.
  */
 declare module 'fastify' {
   interface FastifyReply {
     error: (status: number, options: ErrorOptions) => FastifyReply;
+    status(code: number): FastifyReply;
+    status(code: number, payload: unknown): FastifyReply;
   }
 }
 
 const DEFAULT_ERROR_FORMATTER = (_: number, error: ErrorOptions) => ({ error });
+const DEFAULT_STATUS_FORMATTER = (_: number, payload: unknown) => payload;
+
+function formatErrorPayload(status: number, error: ErrorOptions, plugin: PluginOptions) {
+  if (typeof plugin.format !== 'undefined') {
+    return plugin.format({ kind: 'error', status, error });
+  }
+
+  return DEFAULT_ERROR_FORMATTER(status, error);
+}
+
+function formatStatusPayload(status: number, payload: unknown, plugin: PluginOptions) {
+  if (typeof plugin.format !== 'undefined') {
+    return plugin.format({ kind: 'status', status, payload });
+  }
+
+  return DEFAULT_STATUS_FORMATTER(status, payload);
+}
+
+function patchStatusReplyMethod(reply: FastifyReply, plugin: PluginOptions) {
+  const originalStatus = reply.status.bind(reply) as StatusReplyMethod;
+
+  reply.status = function patchedStatus(code: number, payload?: unknown) {
+    const response = originalStatus(code);
+
+    if (arguments.length >= 2) {
+      return response.send(formatStatusPayload(code, payload, plugin));
+    }
+
+    return response;
+  } as StatusReplyMethod;
+}
 
 async function plugin(fastify: FastifyInstance, plugin: PluginOptions) {
+  fastify.addHook('onRequest', (_, reply, done) => {
+    patchStatusReplyMethod(reply, plugin);
+    done();
+  });
+
   /*
    * Obs.: the anonymous function must not be an arrow function,
-   * probably because of the way the Fastify use `this` context.
+   * probably because of the way the Fastify uses `this` context.
    */
   fastify.decorateReply('error', function (this, status, options) {
-    return this.status(status).send(
-      typeof plugin.format === 'undefined'
-        ? DEFAULT_ERROR_FORMATTER(status, options)
-        : plugin.format(status, options),
-    );
+    return this.status(status).send(formatErrorPayload(status, options, plugin));
   });
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     "outDir": "./dist",
     "esModuleInterop": true
   },
-  "exclude": ["src/server.ts"]
+  "exclude": ["src/server.ts", "dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary\n- introduce a v2 status helper\n- unify kind formatting in one place\n- keep status rendering consistent across outputs\n\n## Notes\n- branch: \n- commit: f805ec1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified formatter for both status and error responses
  * reply.status now supports code-only and code+payload overloads

* **Documentation**
  * Reorganized, simplified docs with Features/Installation/Usage flow
  * Added API section describing the unified formatter and examples

* **Chores**
  * Version bumped to 2.0.0
  * Updated package description to reflect response helper focus
<!-- end of auto-generated comment: release notes by coderabbit.ai -->